### PR TITLE
Update Helm repo URL to use new username

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kubectl create secret generic pghero \
 2. Add custom Helm Chart repository
 
 ```bash
-helm repo add custom-pghero https://gl-canon.github.io/pghero-helmchart && helm repo update 
+helm repo add custom-pghero https://hlebkanonik.github.io/pghero-helmchart && helm repo update 
 ```
 
 3. Fill in values.yaml if necessary. If `secretName` exists, then below `database`, `pgheroUser` and `pgheroUser` fields are not valid

--- a/index.yaml
+++ b/index.yaml
@@ -9,6 +9,6 @@ entries:
     name: pghero
     type: application
     urls:
-    - https://gl-canon.github.io/pghero-helmchart/pghero-v2.8.3.tgz
+    - https://hlebkanonik.github.io/pghero-helmchart/pghero-v2.8.3.tgz
     version: v2.8.3
 generated: "2022-06-30T01:47:31.072663+04:00"


### PR DESCRIPTION
Hi, thanks for this Helm chart!

When trying to install it, I noticed that the URL provided in README.md and charts index is no longer valid. I tried this configuration with my fork and it seems to resolve the issue.